### PR TITLE
Add tree-sitter support; misc. fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ zips
 *~
 #*
 msys64
+*log

--- a/emacs-build.sh
+++ b/emacs-build.sh
@@ -307,6 +307,7 @@ xml2 mingw-libxml2
 gnutls mingw-gnutls
 zlib mingw-zlib
 native-compilation mingw-libgccjit
+tree-sitter mingw-tree-sitter
 EOF
 }
 

--- a/scripts/help.txt
+++ b/scripts/help.txt
@@ -8,8 +8,10 @@ Usage:
 Actions:
    --build       Configure and build Emacs from sources.
    --clean       Remove all directories except sources and zip files.
+   --clean-all   Remove all directories
    --clone       Download Savannah's git repository for Emacs.
    --deps        Create a ZIP file with all the Mingw64/32 dependencies.
+   --ensure      Installs necessary MSYS2 packages.
    --help        Output this help message, --features and exit.
    --pack-emacs  Package an Emacs previously built with the --build option.
    --pack-all    Package an Emacs previously built, with all the Mingw64/32
@@ -22,6 +24,8 @@ Actions:
 
 Build options:
    --branch b    Select Emacs branch (or tag) 'b' for the remaining operations.
+   --master      Same as '--branch master'.
+   --patch       Patches to apply to source tree before building.
    --compress    Ship Emacs with gunzip and compress documentation and Emacs
                  script files.
    --debug       Output all statements run by the script.
@@ -35,11 +39,13 @@ Build options:
                  from the dependencies file. Activate --compress and
                  --strip. (Default configuration)
    --strip       Strip executables and DLL's from debug information.
+   --nativecomp  Add nativecomp feature with full ahead-of-time compilation.
    --with-all    Add all Emacs features.
    --with-*      Add requested feature in the dependencies and build
                  * is any of the known features for emacs in Windows/Mingw
                  (see --features).
    --without-*   Remove requested feature in the dependencies and build.
+   --threads n   Build using 'n' threads.
 
    Options are processed in order. Thus --slim followed by --with-cairo
    would enable Cairo, even though --slim removes it.

--- a/scripts/pdf-tools.sh
+++ b/scripts/pdf-tools.sh
@@ -27,9 +27,9 @@
 
 function action3_pdf_tools ()
 {
-    local pdf_tools_repo="https://github.com/politza/pdf-tools"
+    local pdf_tools_repo="https://github.com/vedang/pdf-tools"
     local pdf_tools_branch="master"
-    local pdf_tools_packages="${mingw_prefix}-poppler ${mingw_prefix}-glib2"
+    local pdf_tools_packages="${mingw_prefix}-poppler ${mingw_prefix}-glib2 automake"
 
     local pdf_tools_source_dir="$emacs_build_git_dir/pdf-tools"
     local pdf_tools_server_dir="$pdf_tools_source_dir/server"


### PR DESCRIPTION
Just found this project and love the simplicity of it. Wanted to give back a few changes I made:

* Add log files to `.gitignore`
* Add `tree-sitter` support
* Add a few missing entries to `--help`
* Repoint `pdf-tools` to the current maintainer's repo (see [here](https://github.com/politza/pdf-tools#pdf-tools-readme))
* Add missing `pdf-tools` dependency on `automake`